### PR TITLE
chore: drop `time 0.1` dependency (RUSTSEC-2020-0071)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,9 @@ name = "chronoutil"
 readme = "README.md"
 repository = "https://github.com/olliemath/chronoutil"
 version = "0.2.3"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 
 [dependencies]
-"chrono" = "^0.4"
+"chrono" = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
We use your crate for our project and it pulls vulnerable `time 0.1` crate.
Now `chrono` made this dependency optional, but unfortunately it's still among default dependencies for backwards compatibility.
See https://rustsec.org/advisories/RUSTSEC-2020-0071.html
